### PR TITLE
creating features by solving bugs 🐞 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 - [0xSplits](https://www.0xsplits.xyz/)
 - [Headless Chaos](https://chaos.build/)
 
+## Testing - Mumbai
+
+- `_nftContractAddress`: `0x1ABDAa80b00340d98E8B80272f930346c839dF85`
+- `_tokenIds`: `[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,60]`
+
 ### ThirdWeb Release
 
 1. Visit [MERGE](https://thirdweb.com/sweetman.eth/MERGE) on Thirdweb.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 - the unofficial plugin for the [0xSplits](https://www.0xsplits.xyz/) protocol.
 
+### Known Issues
+
+- tokenIds.length must be safe divisor (ex. 11 tokens will crash).
+- how to handle multiple tokens owned by the same wallet? increase share for individual or raise % for all?
+
 ### Credits
 
 - [0xSplits](https://www.0xsplits.xyz/)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Liquid Splits
 
-- the unofficial plugin for the [0xSplits](https://www.0xsplits.xyz/) protocol.
+- the unofficial plug-in for the [0xSplits](https://www.0xsplits.xyz/) hyperstructure. 🔌
 
-### Known Issues
+### Features
 
-- tokenIds.length must be safe divisor (ex. 11 tokens will crash).
-- how to handle multiple tokens owned by the same wallet? increase share for individual or raise % for all?
+- bring-your-own-nft. 🌈
+- equitable when one holder owns multiple nfts. 💰
+- supports Zora / OpenSea / 0xSplits / etc. 🍄
 
 ### Credits
 

--- a/contracts/LiquidSplit.sol
+++ b/contracts/LiquidSplit.sol
@@ -17,7 +17,6 @@ contract LiquidSplit is SplitHelpers {
 
     /// @notice distributes ETH to Liquid Split NFT holders
     function withdraw() public {
-        updateHolders();
         address[] memory unsorted = getHolders();
         address[] memory accounts = sortAddresses(unsorted);
         uint32[] memory percentAllocations = getPercentAllocations(accounts);

--- a/contracts/LiquidSplit.sol
+++ b/contracts/LiquidSplit.sol
@@ -17,15 +17,16 @@ contract LiquidSplit is SplitHelpers {
 
     /// @notice distributes ETH to Liquid Split NFT holders
     function withdraw() internal {
-        address[] memory unsorted = getHolders();
-        address[] memory accounts = sortAddresses(unsorted);
-        uint32[] memory percentAllocations = getPercentAllocations(accounts);
+        address[] memory sortedAccounts = getHolders();
+        uint32[] memory percentAllocations = getPercentAllocations(
+            sortedAccounts
+        );
         // atomically deposit funds into split, update recipients to reflect current supercharged NFT holders,
         // and distribute
         payoutSplit.transfer(address(this).balance);
         splitMain.updateAndDistributeETH(
             payoutSplit,
-            accounts,
+            sortedAccounts,
             percentAllocations,
             0,
             address(0)

--- a/contracts/LiquidSplit.sol
+++ b/contracts/LiquidSplit.sol
@@ -16,7 +16,7 @@ contract LiquidSplit is SplitHelpers {
     }
 
     /// @notice distributes ETH to Liquid Split NFT holders
-    function withdraw() public {
+    function withdraw() internal {
         address[] memory unsorted = getHolders();
         address[] memory accounts = sortAddresses(unsorted);
         uint32[] memory percentAllocations = getPercentAllocations(accounts);

--- a/contracts/LiquidSplit.sol
+++ b/contracts/LiquidSplit.sol
@@ -26,7 +26,7 @@ contract LiquidSplit is SplitHelpers {
         payoutSplit.transfer(address(this).balance);
         splitMain.updateAndDistributeETH(
             payoutSplit,
-            sortedAccounts,
+            _uniqueAddresses(sortedAccounts),
             percentAllocations,
             0,
             address(0)

--- a/contracts/lib/PureHelpers.sol
+++ b/contracts/lib/PureHelpers.sol
@@ -22,7 +22,7 @@ contract PureHelpers {
     /// @notice Returns sorted array of accounts for 0xSplits.
     /// @dev sortedAccounts _must_ be sorted for this to work properly
     function _uniqueAddresses(address[] memory sortedAccounts)
-        public
+        internal
         pure
         returns (address[] memory)
     {

--- a/contracts/lib/PureHelpers.sol
+++ b/contracts/lib/PureHelpers.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../interfaces/ISplitMain.sol";
+
+contract PureHelpers {
+    /// @notice Returns sorted array of accounts for 0xSplits.
+    function _sortAddresses(address[] memory addresses)
+        internal
+        pure
+        returns (address[] memory)
+    {
+        for (uint256 i = addresses.length - 1; i > 0; i--)
+            for (uint256 j = 0; j < i; j++)
+                if (addresses[i] < addresses[j])
+                    (addresses[i], addresses[j]) = (addresses[j], addresses[i]);
+
+        return addresses;
+    }
+
+    /// @notice Returns number of unique recipients.
+    /// @dev sortedAccounts _must_ be sorted for this to work properly
+    function _countUniqueRecipients(address[] memory sortedAccounts)
+        internal
+        pure
+        returns (uint32)
+    {
+        uint32 numRecipients = uint32(sortedAccounts.length);
+        uint32 numUniqRecipients = 1;
+        address lastRecipient = sortedAccounts[0];
+        for (uint256 i = 1; i < numRecipients; ) {
+            if (sortedAccounts[i] != lastRecipient) {
+                unchecked {
+                    ++numUniqRecipients;
+                    lastRecipient = sortedAccounts[i];
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        return numUniqRecipients;
+    }
+}

--- a/contracts/lib/PureHelpers.sol
+++ b/contracts/lib/PureHelpers.sol
@@ -19,6 +19,31 @@ contract PureHelpers {
         return addresses;
     }
 
+    /// @notice Returns sorted array of accounts for 0xSplits.
+    /// @dev sortedAccounts _must_ be sorted for this to work properly
+    function _uniqueAddresses(address[] memory sortedAccounts)
+        public
+        pure
+        returns (address[] memory)
+    {
+        uint32 numUniqRecipients = _countUniqueRecipients(sortedAccounts);
+        address[] memory _uniqueRecipients = new address[](numUniqRecipients);
+        _uniqueRecipients[0] = sortedAccounts[0];
+        for (uint32 i = 1; i < numUniqRecipients; ) {
+            uint32 j = i;
+            while (_uniqueRecipients[i - 1] == sortedAccounts[j]) {
+                unchecked {
+                    ++j;
+                }
+            }
+            _uniqueRecipients[i] = sortedAccounts[j];
+            unchecked {
+                ++i;
+            }
+        }
+        return _uniqueRecipients;
+    }
+
     /// @notice Returns number of unique recipients.
     /// @dev sortedAccounts _must_ be sorted for this to work properly
     function _countUniqueRecipients(address[] memory sortedAccounts)

--- a/contracts/lib/SplitHelpers.sol
+++ b/contracts/lib/SplitHelpers.sol
@@ -14,6 +14,9 @@ contract SplitHelpers is PureHelpers {
     IERC721 public nftContract;
     /// @notice array of token holders as split recipients.
     uint32[] public tokenIds;
+    /// @notice constant to scale uints into percentages (1e6 == 100%)
+    uint32 public constant PERCENTAGE_SCALE = 1e6;
+
     /// @notice Funds have been received. activate liquidity.
     event FundsReceived(address indexed source, uint256 amount);
 
@@ -62,21 +65,21 @@ contract SplitHelpers is PureHelpers {
         pure
         returns (uint32[] memory percentAllocations)
     {
-        uint32 numRecipients = uint32(sortedAccounts.length);
         uint32 numUniqRecipients = _countUniqueRecipients(sortedAccounts);
 
         uint32[] memory _percentAllocations = new uint32[](numUniqRecipients);
         for (uint256 i = 0; i < numUniqRecipients; ) {
-            _percentAllocations[i] += uint32(1e6 / numRecipients);
+            _percentAllocations[i] += uint32(
+                PERCENTAGE_SCALE / numUniqRecipients
+            );
             unchecked {
                 ++i;
             }
         }
-        // TODO: replace 1e6 w PERCENTAGE_SCALE or some similarly named constant in contract
         _percentAllocations[0] +=
-            1e6 -
-            uint32(1e6 / numRecipients) *
-            numRecipients;
+            PERCENTAGE_SCALE -
+            uint32(PERCENTAGE_SCALE / numUniqRecipients) *
+            numUniqRecipients;
         return _percentAllocations;
     }
 }

--- a/contracts/lib/SplitHelpers.sol
+++ b/contracts/lib/SplitHelpers.sol
@@ -45,19 +45,15 @@ contract SplitHelpers {
 
     /// @notice Returns array of accounts for current liquid split.
     function getHolders() public view returns (address[] memory) {
-        return holders;
-    }
-
-    /// @notice Returns array of accounts for current liquid split.
-    function updateHolders() public {
-        holders = [nftContract.ownerOf(tokenIds[0])];
-        for (uint256 i = 1; i < tokenIds.length; ) {
-            address holder = nftContract.ownerOf(tokenIds[i]);
-            holders.push(holder);
+        address[] memory _holders = new address[](tokenIds.length);
+        uint256 loopLength = _holders.length;
+        for (uint256 i = 0; i < loopLength; ) {
+            _holders[i] = nftContract.ownerOf(tokenIds[i]);
             unchecked {
                 ++i;
             }
         }
+        return _holders;
     }
 
     /// @notice Returns sorted array of accounts for 0xSplits.


### PR DESCRIPTION
- updated `getHolders`. ✏️ 
- removed `holders[]` state variable. 🚮 
- updated `getPercentAllocations`. ✏️ 
- works with any array of token holders. ✨ 
- equitable when one holder owns multiple tokens. ✨ 
- Example Split: [0xB60731f59646dc47A5DA7600d76F2fC0a6f7Eaf2](https://thirdweb.com/mumbai/0xB60731f59646dc47A5DA7600d76F2fC0a6f7Eaf2/) ✨ 
<img width="532" alt="Screen Shot 2022-09-08 at 2 38 16 PM" src="https://user-images.githubusercontent.com/23249402/189192058-afc64d04-a461-4f78-91f9-35f9ab056754.png">

Split %%% automatically with high precision when NFTs are transferred. 🎯 
<img width="534" alt="Screen Shot 2022-09-08 at 2 38 35 PM" src="https://user-images.githubusercontent.com/23249402/189192063-b2d2f31b-7236-4fb2-bd82-4bcb6ae935ee.png">
